### PR TITLE
Fix for opengl version selection

### DIFF
--- a/include/allegro5/internal/aintern_display.h
+++ b/include/allegro5/internal/aintern_display.h
@@ -171,9 +171,6 @@ void _al_set_color_components(int format, ALLEGRO_EXTRA_DISPLAY_SETTINGS *eds, i
 int  _al_deduce_color_format(ALLEGRO_EXTRA_DISPLAY_SETTINGS *eds);
 int  _al_display_settings_sorter(const void *p0, const void *p1);
 
-int _al_get_suggested_display_option(ALLEGRO_DISPLAY *d,
-   int option, int default_value);
-
 /* This is called from the primitives addon and for shaders. */
 AL_FUNC(void, _al_add_display_invalidated_callback, (ALLEGRO_DISPLAY *display,
    void (*display_invalidated)(ALLEGRO_DISPLAY*)));

--- a/src/display_settings.c
+++ b/src/display_settings.c
@@ -47,17 +47,21 @@ void al_set_new_display_option(int option, int value, int importance)
    extras->settings[option] = value;
 }
 
-
+/**
+  This function uses display->extra_settings, where al_get_new_display_option uses tls->new_display_settings
+  TODO : Remove
+*/
+#if 0
 int _al_get_suggested_display_option(ALLEGRO_DISPLAY *d,
    int option, int default_value)
 {
    ALLEGRO_EXTRA_DISPLAY_SETTINGS *s = &d->extra_settings;
    uint64_t flags = s->required | s->suggested;
-   if (flags & (1 << option))
+   if (flags & ((int64_t)1 << option))
       return s->settings[option];
    return default_value;
 }
-
+#endif
 
 /* Function: al_get_new_display_option
  */

--- a/src/opengl/extensions.c
+++ b/src/opengl/extensions.c
@@ -786,12 +786,20 @@ void _al_ogl_manage_extensions(ALLEGRO_DISPLAY *gl_disp)
    gl_disp->ogl_extras->extension_api = ext_api;
    
 #if !defined ALLEGRO_CFG_OPENGLES
+   int v = al_get_opengl_version();
+
    /* Need that symbol already so can't wait until it is assigned later. */
    glGetStringi = ext_api->GetStringi;
 
    ALLEGRO_DEBUG("OpenGL Extensions:\n");
-   print_extensions_3_0();
 
+   /* glGetString(GL_EXTENSIONS) was deprecated in 3.0 and removed in 3.1 and later versions */
+   if (!(disp->flags & ALLEGRO_OPENGL_3_0) && v < _ALLEGRO_OPENGL_VERSION_3_0) {
+      print_extensions(glGetString(GL_EXTENSIONS));
+   }
+   else {
+      print_extensions_3_0();
+   }
 #endif
 
    /* Create the list of supported extensions. */

--- a/src/opengl/extensions.c
+++ b/src/opengl/extensions.c
@@ -724,15 +724,6 @@ void _al_ogl_manage_extensions(ALLEGRO_DISPLAY *gl_disp)
    ALLEGRO_OGL_EXT_API *ext_api;
    ALLEGRO_OGL_EXT_LIST *ext_list;
 
-   /* Print out OpenGL extensions
-    * We should use glGetStringi(GL_EXTENSIONS, i) for OpenGL 3.0+
-    * but it doesn't seem to work until later.
-    */
-   if (!_al_ogl_version_3_only(gl_disp->flags)) {
-      ALLEGRO_DEBUG("OpenGL Extensions:\n");
-      print_extensions((char const *)glGetString(GL_EXTENSIONS));
-   }
-
    /* Print out GLU version */
    //buf = gluGetString(GLU_VERSION);
    //ALLEGRO_INFO("GLU Version : %s\n", buf);
@@ -798,10 +789,9 @@ void _al_ogl_manage_extensions(ALLEGRO_DISPLAY *gl_disp)
    /* Need that symbol already so can't wait until it is assigned later. */
    glGetStringi = ext_api->GetStringi;
 
-   if (_al_ogl_version_3_only(gl_disp->flags)) {
-      ALLEGRO_DEBUG("OpenGL Extensions:\n");
-      print_extensions_3_0();
-   }
+   ALLEGRO_DEBUG("OpenGL Extensions:\n");
+   print_extensions_3_0();
+
 #endif
 
    /* Create the list of supported extensions. */

--- a/src/opengl/extensions.c
+++ b/src/opengl/extensions.c
@@ -723,7 +723,7 @@ void _al_ogl_manage_extensions(ALLEGRO_DISPLAY *gl_disp)
 #endif
    ALLEGRO_OGL_EXT_API *ext_api;
    ALLEGRO_OGL_EXT_LIST *ext_list;
-
+   
    /* Print out GLU version */
    //buf = gluGetString(GLU_VERSION);
    //ALLEGRO_INFO("GLU Version : %s\n", buf);
@@ -785,19 +785,25 @@ void _al_ogl_manage_extensions(ALLEGRO_DISPLAY *gl_disp)
    load_extensions(ext_api);
    gl_disp->ogl_extras->extension_api = ext_api;
    
+   
+   /* Print out OpenGL extensions for all versions of opengl less than 3
+    * Does this include opengles 2 and 3?
+    * glGetString(GL_EXTENSIONS) was deprecated in OpenGL 3.0
+    * We should use glGetStringi(GL_EXTENSIONS, i) for OpenGL 3.0+
+    * but it doesn't seem to work until later. Note - it doesn't work for some? Who?
+    */
+   if (gl_disp->ogl_extras->ogl_info.version <= _ALLEGRO_OPENGL_VERSION_3_0) {
+      char const* extstr = (char const*)glGetString(GL_EXTENSIONS);
+      ALLEGRO_DEBUG("OpenGL Extensions:\n");
+      print_extensions(extstr);
+   }
+   
 #if !defined ALLEGRO_CFG_OPENGLES
-   int v = al_get_opengl_version();
-
    /* Need that symbol already so can't wait until it is assigned later. */
    glGetStringi = ext_api->GetStringi;
 
-   ALLEGRO_DEBUG("OpenGL Extensions:\n");
-
-   /* glGetString(GL_EXTENSIONS) was deprecated in 3.0 and removed in 3.1 and later versions */
-   if (!(disp->flags & ALLEGRO_OPENGL_3_0) && v < _ALLEGRO_OPENGL_VERSION_3_0) {
-      print_extensions(glGetString(GL_EXTENSIONS));
-   }
-   else {
+   if (gl_disp->ogl_extras->ogl_info.version >= _ALLEGRO_OPENGL_VERSION_3_0) {
+      ALLEGRO_DEBUG("OpenGL Extensions:\n");
       print_extensions_3_0();
    }
 #endif

--- a/src/win/wgl_disp.c
+++ b/src/win/wgl_disp.c
@@ -1058,6 +1058,13 @@ static ALLEGRO_DISPLAY* wgl_create_display(int w, int h)
    ALLEGRO_INFO("Vendor: %s\n", (const char*)glGetString(GL_VENDOR));
    ALLEGRO_INFO("Renderer: %s\n\n", (const char*)glGetString(GL_RENDERER));
 
+   /* Fill in the display settings for opengl major and minor versions...*/
+   int* s = display->extra_settings.settings;
+   s[ALLEGRO_OPENGL_MAJOR_VERSION] = 
+      (display->ogl_extras->ogl_info.version >> 24) & 0xFF;
+   s[ALLEGRO_OPENGL_MINOR_VERSION] = 
+      (display->ogl_extras->ogl_info.version >> 16) & 0xFF;      
+      
    /* Add ourself to the list of displays. */
    add = _al_vector_alloc_back(&system->system.displays);
    *add = wgl_display;

--- a/src/win/wgl_disp.c
+++ b/src/win/wgl_disp.c
@@ -959,10 +959,8 @@ static bool create_display_internals(ALLEGRO_DISPLAY_WGL *wgl_disp)
       return false;
    }
 
-   major = _al_get_suggested_display_option(disp,
-      ALLEGRO_OPENGL_MAJOR_VERSION, 0);
-   minor = _al_get_suggested_display_option(disp,
-      ALLEGRO_OPENGL_MINOR_VERSION, 0);
+   major = al_get_new_display_option(ALLEGRO_OPENGL_MAJOR_VERSION , 0);
+   minor = al_get_new_display_option(ALLEGRO_OPENGL_MINOR_VERSION , 0);
 
    if ((disp->flags & ALLEGRO_OPENGL_3_0) || major != 0) {
       if (major == 0)

--- a/src/x/xglx_config.c
+++ b/src/x/xglx_config.c
@@ -532,10 +532,8 @@ bool _al_xglx_config_create_context(ALLEGRO_DISPLAY_XGLX *glx)
          existing_ctx = (*existing_dpy)->context;
    }
 
-   int major = _al_get_suggested_display_option(disp,
-      ALLEGRO_OPENGL_MAJOR_VERSION, 0);
-   int minor = _al_get_suggested_display_option(disp,
-      ALLEGRO_OPENGL_MINOR_VERSION, 0);
+   int major = al_get_new_display_option(ALLEGRO_OPENGL_MAJOR_VERSION , 0);
+   int minor = al_get_new_display_option(ALLEGRO_OPENGL_MINOR_VERSION , 0);
 
    if (glx->fbc) {
       bool forward_compat = (disp->flags & ALLEGRO_OPENGL_FORWARD_COMPATIBLE) != 0;


### PR DESCRIPTION
Here are some fixes for opengl version selection on Windows and X. They both use a broken function called _al_get_suggested_display_option instead of using al_get_new_display_option. There is also a fix for getting the extensions from opengl so it doesn't crash when trying to create the specific context.

Is there some specific reason for the _al_get_suggested_display_option function? It seems non-useful. I #defined it out in this patch.